### PR TITLE
Add @Laurin-W as a code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @inrupt/sdk-owners
+* @inrupt/sdk-owners @Laurin-W


### PR DESCRIPTION
Being a code owner is required to be able to approve and merge PRs. In particular, this is helpful for Laurin to merge dependabot PRs, and to approve PRs opened by other members of the team.