### PR TITLE
 Fix tsc build issue

### DIFF
--- a/src/pages/generate.tsx
+++ b/src/pages/generate.tsx
@@ -33,11 +33,17 @@ import type { FieldArrayRenderProps } from "formik";
 import { FieldArray, Form, Formik } from "formik";
 import generateClientIdDocument from "../lib/generateDocument";
 
-function RedirectUrisComponent({ push, remove, form }: FieldArrayRenderProps) {
+function RedirectUrisComponent(props: FieldArrayRenderProps | void) {
+  if (!props) {
+    return <Grid container item spacing={1} />;
+  }
+  const { push, remove, form } = props;
   return (
     <Grid container item spacing={1}>
       {form.values.redirectUris.map((redirectUri: string, index: number) => {
         return (
+          // index={key} taken from https://formik.org/docs/examples/field-arrays
+          // this seems fine in this context
           // eslint-disable-next-line react/no-array-index-key
           <Grid container item key={index}>
             <Grid container item xs>
@@ -213,7 +219,7 @@ export default function ClientIdentifierGenerator() {
               <TextField
                 label="Generated JSON"
                 multiline
-                readOnly
+                inputProps={{ readOnly: true }}
                 value={documentJson}
                 fullWidth
                 minRows={15}


### PR DESCRIPTION
Fix tsc build failiures.
One arose from trying to pass a component to the Formik FieldArray that did not accept void as props parameter.
The other issue arose from a wrong props passing of prop readOnly to the TextField component.

This worked fine in development mode but caused issues now.
