### PR TITLE
feat: improve refresh token rule success message

### DIFF
--- a/src/lib/validationRules/refreshTokenRule/refreshTokenRule.test.ts
+++ b/src/lib/validationRules/refreshTokenRule/refreshTokenRule.test.ts
@@ -74,11 +74,22 @@ describe("refresh token request must be set correctly", () => {
     );
   });
 
-  it("succeeds for valid request", async () => {
+  it("succeeds for valid refresh token request", async () => {
     const resultsForSuccess = await refreshTokenRule.check({
       document: {
         grant_types: ["authorization_code", "refresh_token"],
         scope: "openid webid offline_access",
+      },
+    });
+    expect(resultsForSuccess).toHaveLength(1);
+    expect(resultsForSuccess[0].title).toMatch(/Refresh Token rules are met/);
+  });
+
+  it("succeeds for no refresh token request", async () => {
+    const resultsForSuccess = await refreshTokenRule.check({
+      document: {
+        grant_types: ["authorization_code"],
+        scope: "openid webid",
       },
     });
     expect(resultsForSuccess).toHaveLength(1);

--- a/src/lib/validationRules/refreshTokenRule/refreshTokenRule.ts
+++ b/src/lib/validationRules/refreshTokenRule/refreshTokenRule.ts
@@ -71,7 +71,10 @@ const refreshTokenRule: ValidationRule = {
         status: "success",
         title: "Refresh Token rules are met",
         description:
-          "The `grant_types` and the `scope` field align in properties (`refresh_token` and `offline_access`, respectively)",
+          `The \`grant_types\` and the \`scope\` field align in properties (\`refresh_token\` and \`offline_access\`, respectively).` +
+          `A refresh token is ${
+            grantTypesHasRefreshToken ? "" : "_not_ "
+          }requested.`,
         affectedFields: [
           {
             fieldName: "grant_types",


### PR DESCRIPTION
To indicate, whether a document requests a refresh token or not, the refresh token result description will now indicate, if the document requests a refresh token or not. This might be helpful when troubleshooting documents.