### PR TITLE
fix: generateDocument function's defaultMaxAge parameter as string

### DIFF
--- a/src/lib/generateDocument/generateDocument.test.ts
+++ b/src/lib/generateDocument/generateDocument.test.ts
@@ -134,7 +134,7 @@ describe("generateDocument creates correct Client Identifier Documents", () => {
     expect(clientIdDocumentJson.scope.split(" ")).toContain("offline_access");
   });
 
-  it("creates document with redirectUris parameter as string", async () => {
+  it("creates document with redirectUris and defaultMaxAge parameter as string", async () => {
     const clientIdDocument = generateDocument({
       clientId: DEFAULT_CLIENT_IDENTIFIER,
       clientName: DEFAULT_NAME,
@@ -146,11 +146,32 @@ describe("generateDocument creates correct Client Identifier Documents", () => {
       policyUri: "",
       contact: "",
       applicationType: "web",
+      defaultMaxAge: "3600",
     });
 
     const clientIdDocumentJson = JSON.parse(clientIdDocument);
     expect(clientIdDocumentJson.redirect_uris).toHaveLength(1);
     expect(clientIdDocumentJson.redirect_uris[0]).toBe(DEFAULT_REDIRECT_URI);
+    expect(clientIdDocumentJson.default_max_age).toBe(3600);
+  });
+
+  it("ignores invalid defaultMaxAge string parameter", async () => {
+    const clientIdDocument = generateDocument({
+      clientId: DEFAULT_CLIENT_IDENTIFIER,
+      clientName: DEFAULT_NAME,
+      clientUri: DEFAULT_CLIENT_URI,
+      redirectUris: DEFAULT_REDIRECT_URI,
+      useRefreshTokens: false,
+      logoUri: "",
+      tosUri: "",
+      policyUri: "",
+      contact: "",
+      applicationType: "web",
+      defaultMaxAge: "not a number",
+    });
+
+    const clientIdDocumentJson = JSON.parse(clientIdDocument);
+    expect(clientIdDocumentJson.default_max_age).toBeUndefined();
   });
 
   it("creates compacted document", async () => {

--- a/src/lib/generateDocument/generateDocument.ts
+++ b/src/lib/generateDocument/generateDocument.ts
@@ -33,7 +33,7 @@ export interface GenerateClientIdDocumentParameters {
   contact: string;
   applicationType: "web" | "native";
   requireAuthTime?: boolean;
-  defaultMaxAge?: number;
+  defaultMaxAge?: number | string;
   compact?: boolean;
 }
 
@@ -69,7 +69,10 @@ export default function generateClientIdDocument({
     contacts: contact ? [contact] : [],
     application_type: applicationType,
     require_auth_time: requireAuthTime,
-    default_max_age: defaultMaxAge,
+    default_max_age:
+      typeof defaultMaxAge === "string"
+        ? Number(defaultMaxAge) || undefined
+        : defaultMaxAge,
   };
 
   return JSON.stringify(


### PR DESCRIPTION
The generateDocument function expected the defaultMaxAge as type of number. The Mui TextField however set a string to the defaultMaxAge variable which was passed down the generateDocument function (which did not typecheck). The function now accepts strings and converts them to numbers.