### PR TITLE
Feat: Validator UI: paste remote document in textfield for remote validation fetch & validate on enter key

### DIFF
--- a/src/lib/validateRemoteDocument.ts
+++ b/src/lib/validateRemoteDocument.ts
@@ -28,9 +28,9 @@ import { localRules } from "./validationRules";
 
 export default async function validateRemoteDocument(
   documentIri: string
-): Promise<{ validationResults: ValidationResults; document: string }> {
+): Promise<{ validationResults: ValidationResults; document?: string }> {
   if (!documentIri) {
-    return { validationResults: [NO_GIVEN_DOCUMENT_IRI_RESULT], document: "" };
+    return { validationResults: [NO_GIVEN_DOCUMENT_IRI_RESULT] };
   }
   let validationResponse: RemoteValidationResponse;
   try {
@@ -45,7 +45,7 @@ export default async function validateRemoteDocument(
     );
     validationResponse = await fetchResponse.json();
   } catch (error) {
-    return { validationResults: [UNAVAILABLE_API_RESULT], document: "" };
+    return { validationResults: [UNAVAILABLE_API_RESULT] };
   }
 
   const remoteResults = validationResponse.results;
@@ -63,6 +63,8 @@ export default async function validateRemoteDocument(
   const validationResults = [...remoteResults, ...localResults];
   return {
     validationResults,
-    document: JSON.stringify(validationResponse.document, undefined, 2),
+    document: validationResponse.document
+      ? JSON.stringify(validationResponse.document, undefined, 2)
+      : undefined,
   };
 }

--- a/src/lib/validateRemoteDocument.ts
+++ b/src/lib/validateRemoteDocument.ts
@@ -28,9 +28,9 @@ import { localRules } from "./validationRules";
 
 export default async function validateRemoteDocument(
   documentIri: string
-): Promise<ValidationResults> {
+): Promise<{ validationResults: ValidationResults; document: string }> {
   if (!documentIri) {
-    return [NO_GIVEN_DOCUMENT_IRI_RESULT];
+    return { validationResults: [NO_GIVEN_DOCUMENT_IRI_RESULT], document: "" };
   }
   let validationResponse: RemoteValidationResponse;
   try {
@@ -45,7 +45,7 @@ export default async function validateRemoteDocument(
     );
     validationResponse = await fetchResponse.json();
   } catch (error) {
-    return [UNAVAILABLE_API_RESULT];
+    return { validationResults: [UNAVAILABLE_API_RESULT], document: "" };
   }
 
   const remoteResults = validationResponse.results;
@@ -60,5 +60,9 @@ export default async function validateRemoteDocument(
     );
   }
 
-  return [...remoteResults, ...localResults];
+  const validationResults = [...remoteResults, ...localResults];
+  return {
+    validationResults,
+    document: JSON.stringify(validationResponse.document, undefined, 2),
+  };
 }

--- a/src/pages/validate.tsx
+++ b/src/pages/validate.tsx
@@ -133,6 +133,9 @@ function ClientIdentifierValidator() {
                     label="Client Identifier URI"
                     value={clientIdentifierUri}
                     onChange={(e) => setClientIdentifierUri(e.target.value)}
+                    onKeyUp={async (e) => {
+                      if (e.key === "Enter") await fetchAndValidate();
+                    }}
                     size="small"
                     fullWidth
                   />
@@ -172,6 +175,10 @@ function ClientIdentifierValidator() {
                     spellCheck="false"
                     value={documentJson}
                     onChange={(e) => setDocumentJson(e.target.value)}
+                    onKeyUp={async (e) => {
+                      if (e.key === "Enter" && e.ctrlKey)
+                        await onValidateBtnClick();
+                    }}
                   />
                 </Grid>
                 <Grid

--- a/src/pages/validate.tsx
+++ b/src/pages/validate.tsx
@@ -53,8 +53,10 @@ function ClientIdentifierValidator() {
 
   const fetchAndValidate = async () => {
     setIsValidatingRemotely(true);
-    const remoteResults = await validateRemoteDocument(clientIdentifierUri);
+    const { validationResults: remoteResults, document: remoteDocument } =
+      await validateRemoteDocument(clientIdentifierUri);
     setValidationResults(remoteResults);
+    if (remoteDocument) setDocumentJson(remoteDocument);
     setIsValidatingRemotely(false);
   };
 

--- a/src/pages/validate.tsx
+++ b/src/pages/validate.tsx
@@ -22,6 +22,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Typography, Grid, TextField, Button } from "@mui/material";
 import LoadingButton from "@mui/lab/LoadingButton";
+import { useSearchParams } from "react-router-dom";
 import ValidationResults from "../components/validationResults";
 import { localRules } from "../lib/validationRules";
 import validateRemoteDocument from "../lib/validateRemoteDocument";
@@ -30,12 +31,9 @@ import { ValidationResult } from "../lib/types";
 
 function ClientIdentifierValidator() {
   // Get the document from search parameter, if supplied.
-  const searchParamsDocument = new URLSearchParams(window.location.search).get(
-    "document"
-  );
-  const searchParamsDocumentIri = new URLSearchParams(
-    window.location.search
-  ).get("documentIri");
+  const [searchParams] = useSearchParams();
+  const searchParamsDocument = searchParams.get("document");
+  const searchParamsDocumentIri = searchParams.get("documentIri");
 
   const [documentJson, setDocumentJson] = useState(searchParamsDocument || "");
   const [clientIdentifierUri, setClientIdentifierUri] = useState(


### PR DESCRIPTION
- Triggering remote validation will paste the document validated in the text field that is also used for local validation.
- Hitting enter in the Client Identifier URI text field will trigger validation. Pressing ctrl+enter in the "validate form JSON" text field will trigger validation.
- Replace `new URLSearchParameters(window.location.search)` with react router's `useSearchParams()`
