### PR TITLE
feat: rule improvements

### DIFF
--- a/src/lib/helperFunctions.test.ts
+++ b/src/lib/helperFunctions.test.ts
@@ -72,11 +72,17 @@ describe("helper functions", () => {
     it("returns true for '127.0.0.1'", async () => {
       expect(isHostnameLocal("127.0.0.1")).toBe(true);
     });
-    it("returns true for '127.0.0.100'", async () => {
-      expect(isHostnameLocal("127.0.0.100")).toBe(true);
+    it("returns true for '127.255.15.255'", async () => {
+      expect(isHostnameLocal("127.255.15.255")).toBe(true);
     });
     it("returns false for '127.0.0.1000'", async () => {
       expect(isHostnameLocal("127.0.0.1000")).toBe(false);
+    });
+    it("returns false for '127.0.0.-5'", async () => {
+      expect(isHostnameLocal("127.0.0.-5")).toBe(false);
+    });
+    it("returns false for '127.0.0.256.3'", async () => {
+      expect(isHostnameLocal("127.0.0.256.3")).toBe(false);
     });
     it("returns false for '127.0.0.1.2'", async () => {
       expect(isHostnameLocal("127.0.0.1.2")).toBe(false);
@@ -97,7 +103,7 @@ describe("helper functions", () => {
       expect(isUriLocalhost("http://127.0.0.5/")).toBe(true);
     });
     it("returns true for 'http://127.0.0.2.3/'", async () => {
-      expect(isUriLocalhost("http://127.0.2.3/")).toBe(false);
+      expect(isUriLocalhost("http://127.0.2.3/")).toBe(true);
     });
     it("returns false for 'http://127.0.0.500/'", async () => {
       // In Firefox, this will parse as URL,

--- a/src/lib/helperFunctions.test.ts
+++ b/src/lib/helperFunctions.test.ts
@@ -1,0 +1,114 @@
+//
+// Copyright 2022 Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+/* eslint-disable-next-line no-shadow */
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  isHostnameLocal,
+  isUriLocalhost,
+  statusToNumber,
+  underScoreToCamelCase,
+} from "./helperFunctions";
+
+describe("helper functions", () => {
+  describe("underScoreToCamelCase", () => {
+    it("converts name with single underscore", async () => {
+      expect(underScoreToCamelCase("part1_part2")).toBe("part1Part2");
+    });
+    it("converts name with multiple underscores", async () => {
+      expect(underScoreToCamelCase("part1_part2_part3")).toBe(
+        "part1Part2Part3"
+      );
+    });
+    it("leaves name with no underscore", async () => {
+      expect(underScoreToCamelCase("part1")).toBe("part1");
+    });
+  });
+
+  describe("statusToNumber", () => {
+    it("returns 50 for error", async () => {
+      expect(statusToNumber("error")).toBe(50);
+    });
+    it("returns 40 for warning", async () => {
+      expect(statusToNumber("warning")).toBe(40);
+    });
+    it("returns 30 for info", async () => {
+      expect(statusToNumber("info")).toBe(30);
+    });
+    it("returns 20 for success", async () => {
+      expect(statusToNumber("success")).toBe(20);
+    });
+    it("returns 10 for default", async () => {
+      expect(statusToNumber("default")).toBe(10);
+    });
+    it("returns 0 for undefined", async () => {
+      expect(statusToNumber(undefined)).toBe(0);
+    });
+  });
+
+  describe("isHostNameLocal", () => {
+    it("returns true for 'localhost'", async () => {
+      expect(isHostnameLocal("localhost")).toBe(true);
+    });
+    it("returns true for '127.0.0.1'", async () => {
+      expect(isHostnameLocal("127.0.0.1")).toBe(true);
+    });
+    it("returns true for '127.0.0.100'", async () => {
+      expect(isHostnameLocal("127.0.0.100")).toBe(true);
+    });
+    it("returns false for '127.0.0.1000'", async () => {
+      expect(isHostnameLocal("127.0.0.1000")).toBe(false);
+    });
+    it("returns false for '127.0.0.1.2'", async () => {
+      expect(isHostnameLocal("127.0.0.1.2")).toBe(false);
+    });
+    it("returns true for '[::1]'", async () => {
+      expect(isHostnameLocal("[::1]")).toBe(true);
+    });
+  });
+
+  describe("isUriLocalHost", () => {
+    it("returns true for 'https://localhost:300/foo/bar'", async () => {
+      expect(isUriLocalhost("https://localhost:300/foo/bar")).toBe(true);
+    });
+    it("returns true for 'https://[0000:0000::1]:300/foo/bar'", async () => {
+      expect(isUriLocalhost("https://[0000:0000::1]:300/foo/bar")).toBe(true);
+    });
+    it("returns true for 'http://127.0.0.5/'", async () => {
+      expect(isUriLocalhost("http://127.0.0.5/")).toBe(true);
+    });
+    it("returns true for 'http://127.0.0.2.3/'", async () => {
+      expect(isUriLocalhost("http://127.0.2.3/")).toBe(false);
+    });
+    it("returns false for 'http://127.0.0.500/'", async () => {
+      // In Firefox, this will parse as URL,
+      // Chromium and the jest environment throw.
+      expect(isUriLocalhost("http://127.0.0.500/")).toBeFalsy();
+    });
+    it("returns false for 'tel:12345'", async () => {
+      expect(isUriLocalhost("tel:12345")).toBe(false);
+    });
+    it("returns undefined for 'invalid uri'", async () => {
+      expect(isUriLocalhost("invalid uri")).toBeUndefined();
+    });
+  });
+});

--- a/src/lib/helperFunctions.test.ts
+++ b/src/lib/helperFunctions.test.ts
@@ -108,13 +108,13 @@ describe("helper functions", () => {
     it("returns false for 'http://127.0.0.500/'", async () => {
       // In Firefox, this will parse as URL,
       // Chromium and the jest environment throw.
-      expect(isUriLocalhost("http://127.0.0.500/")).toBeFalsy();
+      expect(isUriLocalhost("http://127.0.0.500/")).toBe(false);
     });
     it("returns false for 'tel:12345'", async () => {
       expect(isUriLocalhost("tel:12345")).toBe(false);
     });
     it("returns undefined for 'invalid uri'", async () => {
-      expect(isUriLocalhost("invalid uri")).toBeUndefined();
+      expect(isUriLocalhost("invalid uri")).toBe(false);
     });
   });
 });

--- a/src/lib/helperFunctions.ts
+++ b/src/lib/helperFunctions.ts
@@ -50,11 +50,12 @@ export const isHostnameLocal = (hostname: string) => {
   if (hostname === "localhost" || hostname === "[::1]") {
     return true;
   }
-  if (hostname.startsWith("127.0.0.") && hostname.length <= 11) {
-    const lastBlock = Number(hostname.split("127.0.0.")[1]);
-    if (Number.isInteger(lastBlock) && Number(lastBlock) < 256) {
-      return true;
-    }
+  // Test 127.0.0.0/8 range.
+  const blocks = hostname.split(".");
+  if (blocks.length === 4 && blocks[0] === "127") {
+    return blocks
+      .slice(1)
+      .every((block) => Number(block) >= 0 && Number(block) < 256);
   }
   return false;
 };

--- a/src/lib/helperFunctions.ts
+++ b/src/lib/helperFunctions.ts
@@ -45,3 +45,24 @@ export const statusToNumber = (
   }
   return 0;
 };
+
+export const isHostnameLocal = (hostname: string) => {
+  if (hostname === "localhost" || hostname === "[::1]") {
+    return true;
+  }
+  if (hostname.startsWith("127.0.0.") && hostname.length <= 11) {
+    const lastBlock = Number(hostname.split("127.0.0.")[1]);
+    if (Number.isInteger(lastBlock) && Number(lastBlock) < 256) {
+      return true;
+    }
+  }
+  return false;
+};
+
+export const isUriLocalhost = (uri: string) => {
+  try {
+    return isHostnameLocal(new URL(uri).hostname);
+  } catch (error) {
+    return undefined;
+  }
+};

--- a/src/lib/helperFunctions.ts
+++ b/src/lib/helperFunctions.ts
@@ -46,16 +46,15 @@ export const statusToNumber = (
   return 0;
 };
 
+const LOCALHOST_IP_REGEX = /^127.\d{1,3}.\d{1,3}.\d{1,3}$/;
+
 export const isHostnameLocal = (hostname: string) => {
   if (hostname === "localhost" || hostname === "[::1]") {
     return true;
   }
   // Test 127.0.0.0/8 range.
-  const blocks = hostname.split(".");
-  if (blocks.length === 4 && blocks[0] === "127") {
-    return blocks
-      .slice(1)
-      .every((block) => Number(block) >= 0 && Number(block) < 256);
+  if (LOCALHOST_IP_REGEX.test(hostname)) {
+    return true;
   }
   return false;
 };

--- a/src/lib/helperFunctions.ts
+++ b/src/lib/helperFunctions.ts
@@ -64,6 +64,6 @@ export const isUriLocalhost = (uri: string) => {
   try {
     return isHostnameLocal(new URL(uri).hostname);
   } catch (error) {
-    return undefined;
+    return false;
   }
 };

--- a/src/lib/validationRules.ts
+++ b/src/lib/validationRules.ts
@@ -39,9 +39,11 @@ import { RemoteValidationRule, ValidationRule } from "./types";
 import remoteDocumentAsJsonLd from "./validationRules/remoteDocumentAsJsonLd/remoteDocumentAsJsonLd";
 import remoteMatchingClientId from "./validationRules/remoteMatchingClientId/remoteMatchingClientId";
 import redirectUrisApplicationTypeRule from "./validationRules/redirectUrisApplicationTypeRule/redirectUrisApplicationTypeRule";
+import noLocalhostClientId from "./validationRules/noLocalhostClientId/noLocalhostClientId";
 
 export const localRules: ValidationRule[] = [
   decentClientName,
+  noLocalhostClientId,
   noMixedRedirectUrls,
   noUnknownFields,
   redirectUrisApplicationTypeRule,

--- a/src/lib/validationRules/decentClientName/decentClientName.test.ts
+++ b/src/lib/validationRules/decentClientName/decentClientName.test.ts
@@ -42,6 +42,18 @@ describe("well-formed client name check", () => {
     expect(resultsForInvalidClientName[0].title).toMatch(/Invalid Client Name/);
   });
 
+  it("warns on whitespace client name", async () => {
+    const resultsForLongClientName = await decentClientName.check({
+      document: {
+        client_name: " \n\t\v\r\f",
+      },
+    });
+    expect(resultsForLongClientName).toHaveLength(1);
+    expect(resultsForLongClientName[0].description).toMatch(
+      /The Client Name consists of whitespace only/
+    );
+  });
+
   it("warns on long client name", async () => {
     const resultsForLongClientName = await decentClientName.check({
       document: {

--- a/src/lib/validationRules/decentClientName/decentClientName.test.ts
+++ b/src/lib/validationRules/decentClientName/decentClientName.test.ts
@@ -45,7 +45,7 @@ describe("well-formed client name check", () => {
   it("warns on whitespace client name", async () => {
     const resultsForLongClientName = await decentClientName.check({
       document: {
-        client_name: " \n\t\v\r\f",
+        client_name: "   ",
       },
     });
     expect(resultsForLongClientName).toHaveLength(1);

--- a/src/lib/validationRules/decentClientName/decentClientName.ts
+++ b/src/lib/validationRules/decentClientName/decentClientName.ts
@@ -35,7 +35,12 @@ const decentClientName: ValidationRule = {
           title: "No Client Name present",
           description:
             "The document has no Client Name set. It should be set for authentication providers to display the name to the end-user.",
-          affectedFields: [{ fieldName: "client_name", fieldValue: undefined }],
+          affectedFields: [
+            {
+              fieldName: "client_name",
+              fieldValue: context.document.client_name,
+            },
+          ],
         },
       ];
     }
@@ -63,7 +68,12 @@ const decentClientName: ValidationRule = {
           title: "Invalid Client Name",
           description:
             "The Client Name consists of whitespace only. It should be set for authentication providers to display the name to the end-user.",
-          affectedFields: [{ fieldName: "client_name", fieldValue: undefined }],
+          affectedFields: [
+            {
+              fieldName: "client_name",
+              fieldValue: context.document.client_name,
+            },
+          ],
         },
       ];
     }

--- a/src/lib/validationRules/decentClientName/decentClientName.ts
+++ b/src/lib/validationRules/decentClientName/decentClientName.ts
@@ -60,7 +60,7 @@ const decentClientName: ValidationRule = {
       return [
         {
           status: "warning",
-          title: "Client Name is whitespace only",
+          title: "Invalid Client Name",
           description:
             "The Client Name consists of whitespace only. It should be set for authentication providers to display the name to the end-user.",
           affectedFields: [{ fieldName: "client_name", fieldValue: undefined }],

--- a/src/lib/validationRules/decentClientName/decentClientName.ts
+++ b/src/lib/validationRules/decentClientName/decentClientName.ts
@@ -56,6 +56,18 @@ const decentClientName: ValidationRule = {
       ];
     }
 
+    if (context.document.client_name.trim() === "") {
+      return [
+        {
+          status: "warning",
+          title: "Client Name is whitespace only",
+          description:
+            "The Client Name consists of whitespace only. It should be set for authentication providers to display the name to the end-user.",
+          affectedFields: [{ fieldName: "client_name", fieldValue: undefined }],
+        },
+      ];
+    }
+
     if (context.document.client_name.length > 50) {
       return [
         {

--- a/src/lib/validationRules/noLocalhostClientId/noLocalhostClientId.test.ts
+++ b/src/lib/validationRules/noLocalhostClientId/noLocalhostClientId.test.ts
@@ -21,11 +21,11 @@
 
 /* eslint-disable-next-line no-shadow */
 import { describe, expect, it } from "@jest/globals";
-import decentClientName from "./noLocalhostClientId";
+import noLocalhostClientId from "./noLocalhostClientId";
 
 describe("well-formed client name check", () => {
   it("warns on localhost client_id", async () => {
-    const resultsForLocalhostClientId = await decentClientName.check({
+    const resultsForLocalhostClientId = await noLocalhostClientId.check({
       document: { client_id: "http://localhost:1234" },
     });
     expect(resultsForLocalhostClientId).toHaveLength(1);
@@ -35,14 +35,14 @@ describe("well-formed client name check", () => {
   });
 
   it("passes on valid client_id", async () => {
-    const resultsForLocalhostClientId = await decentClientName.check({
+    const resultsForLocalhostClientId = await noLocalhostClientId.check({
       document: { client_id: "http://app.example" },
     });
     expect(resultsForLocalhostClientId).toHaveLength(0);
   });
 
   it("passes on invalid client_id", async () => {
-    const resultsForLocalhostClientId = await decentClientName.check({
+    const resultsForLocalhostClientId = await noLocalhostClientId.check({
       document: { client_id: "not a uri" },
     });
     expect(resultsForLocalhostClientId).toHaveLength(0);

--- a/src/lib/validationRules/noLocalhostClientId/noLocalhostClientId.test.ts
+++ b/src/lib/validationRules/noLocalhostClientId/noLocalhostClientId.test.ts
@@ -1,0 +1,50 @@
+//
+// Copyright 2022 Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+/* eslint-disable-next-line no-shadow */
+import { describe, expect, it } from "@jest/globals";
+import decentClientName from "./noLocalhostClientId";
+
+describe("well-formed client name check", () => {
+  it("warns on localhost client_id", async () => {
+    const resultsForLocalhostClientId = await decentClientName.check({
+      document: { client_id: "http://localhost:1234" },
+    });
+    expect(resultsForLocalhostClientId).toHaveLength(1);
+    expect(resultsForLocalhostClientId[0].title).toMatch(
+      /Localhost Client Identifier/
+    );
+  });
+
+  it("passes on valid client_id", async () => {
+    const resultsForLocalhostClientId = await decentClientName.check({
+      document: { client_id: "http://app.example" },
+    });
+    expect(resultsForLocalhostClientId).toHaveLength(0);
+  });
+
+  it("passes on invalid client_id", async () => {
+    const resultsForLocalhostClientId = await decentClientName.check({
+      document: { client_id: "not a uri" },
+    });
+    expect(resultsForLocalhostClientId).toHaveLength(0);
+  });
+});

--- a/src/lib/validationRules/noLocalhostClientId/noLocalhostClientId.test.ts
+++ b/src/lib/validationRules/noLocalhostClientId/noLocalhostClientId.test.ts
@@ -30,7 +30,7 @@ describe("well-formed client name check", () => {
     });
     expect(resultsForLocalhostClientId).toHaveLength(1);
     expect(resultsForLocalhostClientId[0].title).toMatch(
-      /Localhost Client Identifier/
+      /Client Identifier uses localhost/
     );
   });
 

--- a/src/lib/validationRules/noLocalhostClientId/noLocalhostClientId.ts
+++ b/src/lib/validationRules/noLocalhostClientId/noLocalhostClientId.ts
@@ -21,21 +21,22 @@
 import { isUriLocalhost } from "../../helperFunctions";
 import { ValidationContext, ValidationRule } from "../../types";
 
+const descriptionMessage =
+  "Client Identifier URIs must be dereferenced by the OIDC Provider and are therefore only useful for development when your client application and OIDC Provider run on the same machine.";
+
 const noLocalhostClientId: ValidationRule = {
   rule: {
     type: "local",
-    name: "Localhost Client IDs in development only",
-    description:
-      "Localhost Client Identifiers should be used for development purposes only.",
+    name: "The Client Identifier URI field should not use localhost",
+    description: descriptionMessage,
   },
   check: async (context: ValidationContext) => {
     if (isUriLocalhost(String(context.document.client_id))) {
       return [
         {
           status: "warning",
-          title: "Localhost Client Identifier",
-          description:
-            "Client Identifier URIs must be dereferenced by the OIDC Provider and are therefore only useful for development when your client and OP run on the same machine.",
+          title: "Client Identifier uses localhost for `client_id`",
+          description: descriptionMessage,
           affectedFields: [
             { fieldName: "client_id", fieldValue: context.document.client_id },
           ],

--- a/src/lib/validationRules/noLocalhostClientId/noLocalhostClientId.ts
+++ b/src/lib/validationRules/noLocalhostClientId/noLocalhostClientId.ts
@@ -1,0 +1,49 @@
+//
+// Copyright 2022 Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { isUriLocalhost } from "../../helperFunctions";
+import { ValidationContext, ValidationRule } from "../../types";
+
+const noLocalhostClientId: ValidationRule = {
+  rule: {
+    type: "local",
+    name: "Localhost Client IDs in development only",
+    description:
+      "Localhost Client Identifiers should be used for development purposes only.",
+  },
+  check: async (context: ValidationContext) => {
+    if (isUriLocalhost(String(context.document.client_id))) {
+      return [
+        {
+          status: "warning",
+          title: "Localhost Client Identifier",
+          description:
+            "Client Identifier URIs must be dereferenced by the OIDC Provider and are therefore only useful for development when your client and OP run on the same machine.",
+          affectedFields: [
+            { fieldName: "client_id", fieldValue: context.document.client_id },
+          ],
+        },
+      ];
+    }
+    return [];
+  },
+};
+
+export default noLocalhostClientId;

--- a/src/lib/validationRules/noLocalhostClientId/noLocalhostClientId.ts
+++ b/src/lib/validationRules/noLocalhostClientId/noLocalhostClientId.ts
@@ -21,14 +21,12 @@
 import { isUriLocalhost } from "../../helperFunctions";
 import { ValidationContext, ValidationRule } from "../../types";
 
-const descriptionMessage =
-  "Client Identifier URIs must be dereferenced by the OIDC Provider and are therefore only useful for development when your client application and OIDC Provider run on the same machine.";
-
 const noLocalhostClientId: ValidationRule = {
   rule: {
     type: "local",
     name: "The Client Identifier URI field should not use localhost",
-    description: descriptionMessage,
+    description:
+      "A localhost Client Identifier URI cannot be dereferenced by a remote OIDC Provider and is therefore only useful for local development.",
   },
   check: async (context: ValidationContext) => {
     if (isUriLocalhost(String(context.document.client_id))) {
@@ -36,7 +34,8 @@ const noLocalhostClientId: ValidationRule = {
         {
           status: "warning",
           title: "Client Identifier uses localhost for `client_id`",
-          description: descriptionMessage,
+          description:
+            "Client Identifier URIs must be dereferenced by the OIDC Provider and are therefore only useful for development when your client application and OIDC Provider run on the same machine.",
           affectedFields: [
             { fieldName: "client_id", fieldValue: context.document.client_id },
           ],

--- a/src/lib/validationRules/noMixedRedirectUris/noMixedRedirectUrls.ts
+++ b/src/lib/validationRules/noMixedRedirectUris/noMixedRedirectUrls.ts
@@ -18,6 +18,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+import { isHostnameLocal, isUriLocalhost } from "../../helperFunctions";
 import { ValidationContext, ValidationRule } from "../../types";
 
 const noMixedRedirectUrls: ValidationRule = {
@@ -30,18 +31,9 @@ const noMixedRedirectUrls: ValidationRule = {
     if (!Array.isArray(context.document.redirect_uris)) {
       return [];
     }
-    const localHostCount = context.document.redirect_uris.filter((uri) => {
-      try {
-        const url = new URL(uri);
-        return (
-          url.hostname === "localhost" ||
-          url.hostname === "[::1]" ||
-          (url.hostname.startsWith("127.0.0.") && url.hostname.length <= 11)
-        );
-      } catch {
-        return false;
-      }
-    }).length;
+    const localHostCount = context.document.redirect_uris.filter((uri) =>
+      isUriLocalhost(uri)
+    ).length;
 
     if (
       localHostCount !== 0 &&

--- a/src/lib/validationRules/noMixedRedirectUris/noMixedRedirectUrls.ts
+++ b/src/lib/validationRules/noMixedRedirectUris/noMixedRedirectUrls.ts
@@ -18,7 +18,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-import { isHostnameLocal, isUriLocalhost } from "../../helperFunctions";
+import { isUriLocalhost } from "../../helperFunctions";
 import { ValidationContext, ValidationRule } from "../../types";
 
 const noMixedRedirectUrls: ValidationRule = {

--- a/src/lib/validationRules/redirectUrisApplicationTypeRule/redirectUrisApplicationTypeRule.ts
+++ b/src/lib/validationRules/redirectUrisApplicationTypeRule/redirectUrisApplicationTypeRule.ts
@@ -19,6 +19,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+import { isUriLocalhost } from "../../helperFunctions";
 import { ValidationRule, RuleResult, ValidationContext } from "../../types";
 
 const redirectUrisApplicationTypeRule: ValidationRule = {
@@ -29,14 +30,6 @@ const redirectUrisApplicationTypeRule: ValidationRule = {
       "Apps with `application_type` `web` must use https protocol for remote hosts or at least http for localhost clients. Clients with `application_type` `native` must use a custom scheme or http(s) on localhost.",
   },
   check: async (context: ValidationContext) => {
-    const isUrlLocalhost = (url: URL): boolean => {
-      return (
-        url.hostname === "localhost" ||
-        (url.hostname.startsWith("127.0.0.") && url.hostname.length <= 11) ||
-        url.hostname === "[::1]"
-      );
-    };
-
     const checkUri = (uri: string, index: number): RuleResult[] => {
       let url: URL;
       try {
@@ -48,7 +41,7 @@ const redirectUrisApplicationTypeRule: ValidationRule = {
       if (
         (context.document.application_type === "web" ||
           context.document.application_type === undefined) &&
-        !isUrlLocalhost(url) &&
+        !isUriLocalhost(uri) &&
         url.protocol === "http:"
       ) {
         return [
@@ -92,7 +85,7 @@ const redirectUrisApplicationTypeRule: ValidationRule = {
 
       if (
         context.document.application_type === "native" &&
-        !isUrlLocalhost(url) &&
+        !isUriLocalhost(uri) &&
         (url.protocol === "https:" || url.protocol === "http:")
       ) {
         return [

--- a/src/lib/validationRules/rightAuthenticationMethod/rightAuthenticationMethod.ts
+++ b/src/lib/validationRules/rightAuthenticationMethod/rightAuthenticationMethod.ts
@@ -25,7 +25,7 @@ const rightAuthenticationMethod: ValidationRule = {
     type: "local",
     name: "Field `token_endpoint_auth_method` must be `none`.",
     description:
-      "Solid OIDC connect does only support `token_endpoint_auth_method` set to `none`. This must be made explicit to comply with the OIDC specification.",
+      "Authentication with Client Identifier Documents is only supported with `token_endpoint_auth_method` set to `none`. This must be made explicit to comply with the Solid OIDC specification.",
   },
   check: async (context: ValidationContext) => {
     // Emits warning, if unset, as this is not spec-compliant but would probably work with a solid OIDC server
@@ -35,7 +35,7 @@ const rightAuthenticationMethod: ValidationRule = {
           status: "error",
           title: "Field `token_endpoint_auth_method` unset.",
           description:
-            "The field `token_endpoint_auth_method` should be explicitly set to `none`. As per the OpenID spec, the default value is `client_secret_basic` which is not valid for Solid OpenID. For a solid authentication server, an unset value might work but as of the spec, it is undefined behavior.",
+            "The field `token_endpoint_auth_method` should be explicitly set to `none`. As per the OpenID spec, the default value is `client_secret_basic` which is not valid for using Client Identifier Documents. For a solid authentication server, an unset value might work but as of the spec, it is undefined behavior.",
           affectedFields: [
             {
               fieldName: "token_endpoint_auth_method",
@@ -52,7 +52,7 @@ const rightAuthenticationMethod: ValidationRule = {
           status: "error",
           title: "Field `token_endpoint_auth_method` must be set to `none`.",
           description:
-            "The field `token_endpoint_auth_method` must be set to `none`.",
+            "The field `token_endpoint_auth_method` must be set to `none` for authentication with Client Identifier Documents.",
           affectedFields: [
             {
               fieldName: "token_endpoint_auth_method",

--- a/src/lib/validationRules/rightAuthenticationMethod/rightAuthenticationMethod.ts
+++ b/src/lib/validationRules/rightAuthenticationMethod/rightAuthenticationMethod.ts
@@ -25,7 +25,7 @@ const rightAuthenticationMethod: ValidationRule = {
     type: "local",
     name: "Field `token_endpoint_auth_method` must be `none`.",
     description:
-      "Authentication with Client Identifier Documents is only supported with `token_endpoint_auth_method` set to `none`. This must be made explicit to comply with the Solid OIDC specification.",
+      "Authentication with Client Identifier Documents is only supported with `token_endpoint_auth_method` set to `none` as of the Solid OIDC specification. Note that not all OIDC Providers are strict on this policy.",
   },
   check: async (context: ValidationContext) => {
     // Emits warning, if unset, as this is not spec-compliant but would probably work with a solid OIDC server


### PR DESCRIPTION
- Change authentication method rule result description to say token_endpoint_auth_method with client_secret_basic is not supported for Client Identifier Documents (instead of not supported by Solid OIDC)

- Add no localhost Client ID rule

- Add whitespace-only client name rule result