### PR TITLE
fix: broken font uris

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -22,7 +22,7 @@ import { createTheme } from "@mui/material/styles";
 
 const theme = createTheme({
   typography: {
-    fontFamily: `"Raleway", "Roboto", "sans-serif"`,
+    fontFamily: `"Raleway", "sans-serif"`,
     h1: {
       fontWeight: 800,
       fontSize: 22,

--- a/static/fonts.css
+++ b/static/fonts.css
@@ -6,7 +6,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url(/static/fonts/roboto-latin-ext.woff2) format('woff2');
+  src: url(/static/fonts/raleway-latin-ext.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -15,7 +15,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url(/static/fonts/roboto-latin.woff2) format('woff2');
+  src: url(/static/fonts/raleway-latin.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -25,7 +25,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/static/fonts/roboto-latin-ext.woff2) format('woff2');
+  src: url(/static/fonts/raleway-latin-ext.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -34,7 +34,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url(/static/fonts/roboto-latin.woff2) format('woff2');
+  src: url(/static/fonts/raleway-latin.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -44,7 +44,7 @@
   font-style: normal;
   font-weight: 800;
   font-display: swap;
-  src: url(/static/fonts/roboto-latin-ext.woff2) format('woff2');
+  src: url(/static/fonts/raleway-latin-ext.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -53,7 +53,7 @@
   font-style: normal;
   font-weight: 800;
   font-display: swap;
-  src: url(/static/fonts/roboto-latin.woff2) format('woff2');
+  src: url(/static/fonts/raleway-latin.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 


### PR DESCRIPTION
Change links in `fonts.css` from (non-existent) roboto to raleway.